### PR TITLE
added max potion to item recycle filter

### DIFF
--- a/PokemonGo/RocketAPI/Console/Settings.cs
+++ b/PokemonGo/RocketAPI/Console/Settings.cs
@@ -49,26 +49,20 @@ namespace PokemonGo.RocketAPI.Console
 
         public bool Recycler => GetSetting() != string.Empty ? System.Convert.ToBoolean(GetSetting(), CultureInfo.InvariantCulture) : false;
 
-        ICollection<KeyValuePair<ItemId, int>> ISettings.ItemRecycleFilter
+        ICollection<KeyValuePair<ItemId, int>> ISettings.ItemRecycleFilter => new[]
         {
-            get
-            {
-                //Type and amount to keep
-                return new[]
-                {
-                    new KeyValuePair<ItemId, int>(ItemId.ItemPokeBall, 20),
-                    new KeyValuePair<ItemId, int>(ItemId.ItemGreatBall, 50),
-                    new KeyValuePair<ItemId, int>(ItemId.ItemUltraBall, 100),
-                    new KeyValuePair<ItemId, int>(ItemId.ItemMasterBall, 200),
-                    new KeyValuePair<ItemId, int>(ItemId.ItemRazzBerry, 20),
-                    new KeyValuePair<ItemId, int>(ItemId.ItemRevive, 20),
-                    new KeyValuePair<ItemId, int>(ItemId.ItemMaxRevive, 40),
-                    new KeyValuePair<ItemId, int>(ItemId.ItemPotion, 0),
-                    new KeyValuePair<ItemId, int>(ItemId.ItemSuperPotion, 0),
-                    new KeyValuePair<ItemId, int>(ItemId.ItemHyperPotion, 50)
-                };
-            }
-        }
+           new KeyValuePair<ItemId, int>(ItemId.ItemPokeBall, 20),
+           new KeyValuePair<ItemId, int>(ItemId.ItemGreatBall, 50),
+           new KeyValuePair<ItemId, int>(ItemId.ItemUltraBall, 100),
+           new KeyValuePair<ItemId, int>(ItemId.ItemMasterBall, 200),
+           new KeyValuePair<ItemId, int>(ItemId.ItemRazzBerry, 20),
+           new KeyValuePair<ItemId, int>(ItemId.ItemRevive, 20),
+           new KeyValuePair<ItemId, int>(ItemId.ItemMaxRevive, 40),
+           new KeyValuePair<ItemId, int>(ItemId.ItemPotion, 0),
+           new KeyValuePair<ItemId, int>(ItemId.ItemSuperPotion, 0),
+           new KeyValuePair<ItemId, int>(ItemId.ItemHyperPotion, 50),
+           new KeyValuePair<ItemId, int>(ItemId.ItemMaxPotion, 100) 
+        };
 
         public int RecycleItemsInterval => GetSetting() != string.Empty ? Convert.ToInt16(GetSetting()) : 60;
 


### PR DESCRIPTION
After hitting level 25, I realised there was no recycle filter for max potions :)

Also refactored ISettings.ItemRecycleFilter to use an expression body rather than a method, personal preference but I find it cleaner!
