### PR TITLE
Obfuscated password textboxes

### DIFF
--- a/PokemonGo/RocketAPI/Window/SettingsForm.Designer.cs
+++ b/PokemonGo/RocketAPI/Window/SettingsForm.Designer.cs
@@ -187,6 +187,7 @@
             // 
             this.ptcPassText.Location = new System.Drawing.Point(68, 62);
             this.ptcPassText.Name = "ptcPassText";
+            this.ptcPassText.PasswordChar = '•';
             this.ptcPassText.Size = new System.Drawing.Size(136, 20);
             this.ptcPassText.TabIndex = 12;
             // 
@@ -470,6 +471,7 @@
             // 
             this.EmailPasswordBox.Location = new System.Drawing.Point(68, 62);
             this.EmailPasswordBox.Name = "EmailPasswordBox";
+            this.EmailPasswordBox.PasswordChar = '•';
             this.EmailPasswordBox.Size = new System.Drawing.Size(136, 20);
             this.EmailPasswordBox.TabIndex = 30;
             // 


### PR DESCRIPTION
The passwords for both Google and PTC Login are now properly hidden/obfuscated so you can safely open the settings dialog while somebody is looking over your shoulder without having to sacrifice the security/integrity of your account.
