### PR TITLE
Change settings form opening as show dialog

### DIFF
--- a/PokemonGo/RocketAPI/Window/MainForm.cs
+++ b/PokemonGo/RocketAPI/Window/MainForm.cs
@@ -1084,7 +1084,7 @@ namespace PokemonGo.RocketAPI.Window
         private void settingsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             SettingsForm settingsForm = new SettingsForm();
-            settingsForm.Show();
+            settingsForm.ShowDialog();
         }
 
         private static bool bot_started = false;
@@ -1213,7 +1213,7 @@ namespace PokemonGo.RocketAPI.Window
         private void todoToolStripMenuItem_Click(object sender, EventArgs e)
         {
             SettingsForm settingsForm = new SettingsForm();
-            settingsForm.Show();
+            settingsForm.ShowDialog();
         }
 
         private void pokemonToolStripMenuItem2_Click(object sender, EventArgs e)


### PR DESCRIPTION
Changed settingsForm.Show(); in settingsForm.ShowDialog(); to avoid the possibile to open multiple settings form which is usless. That can create problems if a user doesn't make attention and opens more instances of this form.
With .ShoWDialog() we avoid this problem you must be open just 1 form at time
