### PR TITLE
add wait for client.GetMapObjects()

### DIFF
--- a/PokemonGo/RocketAPI/Window/MainForm.cs
+++ b/PokemonGo/RocketAPI/Window/MainForm.cs
@@ -415,6 +415,8 @@ namespace PokemonGo.RocketAPI.Window
 
         private async Task ExecuteCatchAllNearbyPokemons(Client client)
         {
+            await Task.Delay(3000);
+             
             var mapObjects = await client.GetMapObjects();
 
             var pokemons = mapObjects.MapCells.SelectMany(i => i.CatchablePokemons);


### PR DESCRIPTION
When calling this to fast no pokemons are returned, wait a few seconds to get the nearby pokemons.

client.GetMapObjects() does not return when called to fast added 3 sec wait
