### PR TITLE
Add new transfering mode: CP/IV Duplicate

### DIFF
--- a/PokemonGo/RocketAPI/Window/MainForm.cs
+++ b/PokemonGo/RocketAPI/Window/MainForm.cs
@@ -314,11 +314,14 @@ namespace PokemonGo.RocketAPI.Window
                     case "All":
                         await TransferAllGivenPokemons(client, pokemons);
                         break;
-                    case "Duplicate":
+                    case "CP Duplicate":
                         await TransferDuplicatePokemon(client);
                         break;
                     case "IV Duplicate":
                         await TransferDuplicateIVPokemon(client);
+                        break;
+                    case "CP/IV Duplicate":
+                        await TransferDuplicateCPIVPokemon(client);
                         break;
                     case "CP":
                         await TransferAllWeakPokemon(client, ClientSettings.TransferCPThreshold);
@@ -480,11 +483,14 @@ namespace PokemonGo.RocketAPI.Window
                     case "All":
                         await TransferAllGivenPokemons(client, pokemons2);
                         break;
-                    case "Duplicate":
+                    case "CP Duplicate":
                         await TransferDuplicatePokemon(client);
                         break;
                     case "IV Duplicate":
                         await TransferDuplicateIVPokemon(client);
+                        break;
+                    case "CP/IV Duplicate":
+                        await TransferDuplicateCPIVPokemon(client);
                         break;
                     case "CP":
                         await TransferAllWeakPokemon(client, ClientSettings.TransferCPThreshold);
@@ -846,6 +852,57 @@ namespace PokemonGo.RocketAPI.Window
                             pokemonName = Convert.ToString(dubpokemon.PokemonId);
                         ColoredConsoleWrite(Color.DarkGreen,
                             $"Transferred {pokemonName} with {Math.Round(Perfect(dubpokemon))}% IV (Highest is {Math.Round(Perfect(dupes.ElementAt(i).Last().value))}% IV)");
+
+                    }
+                }
+            }
+        }
+
+        private async Task TransferDuplicateCPIVPokemon(Client client)
+        {
+
+            //ColoredConsoleWrite(Color.White, $"Check for CP/IV duplicates");
+            var inventory = await client.GetInventory();
+            var allpokemons =
+                inventory.InventoryDelta.InventoryItems.Select(i => i.InventoryItemData?.Pokemon)
+                    .Where(p => p != null && p?.PokemonId > 0);
+
+            var dupes = allpokemons.OrderBy(x => Perfect(x)).Select((x, i) => new { index = i, value = x })
+                .GroupBy(x => x.value.PokemonId)
+                .Where(x => x.Skip(1).Any());
+
+            for (var i = 0; i < dupes.Count(); i++)
+            {
+                var dupe_group = dupes.ElementAt(i);
+                var max_cp = 0;
+                var max_index = -1;
+                for (var j = 0; j < dupe_group.Count(); j++)
+                {
+                    var this_cp = dupe_group.ElementAt(j).value.Cp;
+                    if (this_cp >= max_cp)
+                    {
+                        max_cp = this_cp;
+                        max_index = j;
+                    }
+                }
+                for (var j = 0; j < dupes.ElementAt(i).Count() - 1; j++)
+                {
+                    var dubpokemon = dupes.ElementAt(i).ElementAt(j).value;
+                    if (dubpokemon.Favorite == 0 && j != max_index)
+                    {
+                        var transfer = await client.TransferPokemon(dubpokemon.Id);
+                        string pokemonName;
+                        if (ClientSettings.Language == "german")
+                        {
+                            string name_english = Convert.ToString(dubpokemon.PokemonId);
+                            var request = (HttpWebRequest)WebRequest.Create("http://boosting-service.de/pokemon/index.php?pokeName=" + name_english);
+                            var response = (HttpWebResponse)request.GetResponse();
+                            pokemonName = new StreamReader(response.GetResponseStream()).ReadToEnd();
+                        }
+                        else
+                            pokemonName = Convert.ToString(dubpokemon.PokemonId);
+                        ColoredConsoleWrite(Color.DarkGreen,
+                            $"Transferred {pokemonName} with {dubpokemon.Cp} CP, {Math.Round(Perfect(dubpokemon))}% IV (Highest is {max_cp} CP/{Math.Round(Perfect(dupes.ElementAt(i).Last().value))}% IV)");
 
                     }
                 }

--- a/PokemonGo/RocketAPI/Window/SettingsForm.Designer.cs
+++ b/PokemonGo/RocketAPI/Window/SettingsForm.Designer.cs
@@ -69,9 +69,9 @@
             // authTypeLabel
             // 
             this.authTypeLabel.AutoSize = true;
-            this.authTypeLabel.Location = new System.Drawing.Point(3, 7);
+            this.authTypeLabel.Location = new System.Drawing.Point(3, 8);
             this.authTypeLabel.Name = "authTypeLabel";
-            this.authTypeLabel.Size = new System.Drawing.Size(71, 12);
+            this.authTypeLabel.Size = new System.Drawing.Size(63, 13);
             this.authTypeLabel.TabIndex = 0;
             this.authTypeLabel.Text = "Login Type:";
             this.authTypeLabel.Click += new System.EventHandler(this.authTypeLabel_Click);
@@ -84,70 +84,70 @@
             "Ptc"});
             this.authTypeCb.Location = new System.Drawing.Point(82, 4);
             this.authTypeCb.Name = "authTypeCb";
-            this.authTypeCb.Size = new System.Drawing.Size(136, 20);
+            this.authTypeCb.Size = new System.Drawing.Size(136, 21);
             this.authTypeCb.TabIndex = 1;
             this.authTypeCb.SelectedIndexChanged += new System.EventHandler(this.authTypeCb_SelectedIndexChanged);
             // 
             // UserLabel
             // 
             this.UserLabel.AutoSize = true;
-            this.UserLabel.Location = new System.Drawing.Point(3, 33);
+            this.UserLabel.Location = new System.Drawing.Point(3, 36);
             this.UserLabel.Name = "UserLabel";
-            this.UserLabel.Size = new System.Drawing.Size(59, 12);
+            this.UserLabel.Size = new System.Drawing.Size(58, 13);
             this.UserLabel.TabIndex = 2;
             this.UserLabel.Text = "Username:";
             // 
             // PasswordLabel
             // 
             this.PasswordLabel.AutoSize = true;
-            this.PasswordLabel.Location = new System.Drawing.Point(3, 57);
+            this.PasswordLabel.Location = new System.Drawing.Point(3, 62);
             this.PasswordLabel.Name = "PasswordLabel";
-            this.PasswordLabel.Size = new System.Drawing.Size(59, 12);
+            this.PasswordLabel.Size = new System.Drawing.Size(56, 13);
             this.PasswordLabel.TabIndex = 3;
             this.PasswordLabel.Text = "Password:";
             // 
             // latLabel
             // 
             this.latLabel.AutoSize = true;
-            this.latLabel.Location = new System.Drawing.Point(3, 81);
+            this.latLabel.Location = new System.Drawing.Point(3, 88);
             this.latLabel.Name = "latLabel";
-            this.latLabel.Size = new System.Drawing.Size(59, 12);
+            this.latLabel.Size = new System.Drawing.Size(48, 13);
             this.latLabel.TabIndex = 4;
             this.latLabel.Text = "Latitude:";
             // 
             // longiLabel
             // 
             this.longiLabel.AutoSize = true;
-            this.longiLabel.Location = new System.Drawing.Point(3, 105);
+            this.longiLabel.Location = new System.Drawing.Point(3, 114);
             this.longiLabel.Name = "longiLabel";
-            this.longiLabel.Size = new System.Drawing.Size(65, 12);
+            this.longiLabel.Size = new System.Drawing.Size(57, 13);
             this.longiLabel.TabIndex = 5;
             this.longiLabel.Text = "Longitude:";
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(3, 129);
+            this.label1.Location = new System.Drawing.Point(3, 140);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(95, 12);
+            this.label1.Size = new System.Drawing.Size(87, 13);
             this.label1.TabIndex = 6;
             this.label1.Text = "Razzberry Mode:";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(3, 178);
+            this.label2.Location = new System.Drawing.Point(3, 193);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(89, 12);
+            this.label2.Size = new System.Drawing.Size(76, 13);
             this.label2.TabIndex = 7;
             this.label2.Text = "Transfer Type:";
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(3, 296);
+            this.label3.Location = new System.Drawing.Point(3, 321);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(95, 12);
+            this.label3.Size = new System.Drawing.Size(91, 13);
             this.label3.TabIndex = 8;
             this.label3.Text = "Evolve Pokemon:";
             this.label3.Click += new System.EventHandler(this.label3_Click);
@@ -155,49 +155,49 @@
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(3, 203);
+            this.label4.Location = new System.Drawing.Point(3, 220);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(83, 12);
+            this.label4.Size = new System.Drawing.Size(74, 13);
             this.label4.TabIndex = 9;
             this.label4.Text = "CP Threshold:";
             // 
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(3, 154);
+            this.label5.Location = new System.Drawing.Point(3, 167);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(113, 12);
+            this.label5.Size = new System.Drawing.Size(93, 13);
             this.label5.TabIndex = 10;
             this.label5.Text = "Razzberry Setting:";
             // 
             // UserLoginBox
             // 
-            this.UserLoginBox.Location = new System.Drawing.Point(82, 31);
+            this.UserLoginBox.Location = new System.Drawing.Point(82, 34);
             this.UserLoginBox.Name = "UserLoginBox";
-            this.UserLoginBox.Size = new System.Drawing.Size(136, 21);
+            this.UserLoginBox.Size = new System.Drawing.Size(136, 20);
             this.UserLoginBox.TabIndex = 11;
             // 
             // UserPasswordBox
             // 
-            this.UserPasswordBox.Location = new System.Drawing.Point(82, 57);
+            this.UserPasswordBox.Location = new System.Drawing.Point(82, 62);
             this.UserPasswordBox.Name = "UserPasswordBox";
-            this.UserPasswordBox.Size = new System.Drawing.Size(136, 21);
+            this.UserPasswordBox.Size = new System.Drawing.Size(136, 20);
             this.UserPasswordBox.TabIndex = 12;
             // 
             // latitudeText
             // 
-            this.latitudeText.Location = new System.Drawing.Point(118, 79);
+            this.latitudeText.Location = new System.Drawing.Point(118, 86);
             this.latitudeText.Name = "latitudeText";
             this.latitudeText.ReadOnly = true;
-            this.latitudeText.Size = new System.Drawing.Size(100, 21);
+            this.latitudeText.Size = new System.Drawing.Size(100, 20);
             this.latitudeText.TabIndex = 13;
             // 
             // longitudeText
             // 
-            this.longitudeText.Location = new System.Drawing.Point(118, 103);
+            this.longitudeText.Location = new System.Drawing.Point(118, 112);
             this.longitudeText.Name = "longitudeText";
             this.longitudeText.ReadOnly = true;
-            this.longitudeText.Size = new System.Drawing.Size(100, 21);
+            this.longitudeText.Size = new System.Drawing.Size(100, 20);
             this.longitudeText.TabIndex = 14;
             // 
             // razzmodeCb
@@ -206,16 +206,16 @@
             this.razzmodeCb.Items.AddRange(new object[] {
             "probability",
             "cp"});
-            this.razzmodeCb.Location = new System.Drawing.Point(118, 127);
+            this.razzmodeCb.Location = new System.Drawing.Point(118, 138);
             this.razzmodeCb.Name = "razzmodeCb";
-            this.razzmodeCb.Size = new System.Drawing.Size(100, 20);
+            this.razzmodeCb.Size = new System.Drawing.Size(100, 21);
             this.razzmodeCb.TabIndex = 15;
             // 
             // razzSettingText
             // 
-            this.razzSettingText.Location = new System.Drawing.Point(118, 152);
+            this.razzSettingText.Location = new System.Drawing.Point(118, 165);
             this.razzSettingText.Name = "razzSettingText";
-            this.razzSettingText.Size = new System.Drawing.Size(100, 21);
+            this.razzSettingText.Size = new System.Drawing.Size(100, 20);
             this.razzSettingText.TabIndex = 16;
             this.razzSettingText.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.razzSettingText_KeyPress);
             // 
@@ -227,27 +227,28 @@
             "CP",
             "IV",
             "Leave Strongest",
-            "Duplicate",
+            "CP Duplicate",
             "IV Duplicate",
+            "CP/IV Duplicate",
             "All"});
-            this.transferTypeCb.Location = new System.Drawing.Point(118, 176);
+            this.transferTypeCb.Location = new System.Drawing.Point(118, 191);
             this.transferTypeCb.Name = "transferTypeCb";
-            this.transferTypeCb.Size = new System.Drawing.Size(100, 20);
+            this.transferTypeCb.Size = new System.Drawing.Size(100, 21);
             this.transferTypeCb.TabIndex = 17;
             this.transferTypeCb.SelectedIndexChanged += new System.EventHandler(this.transferTypeCb_SelectedIndexChanged);
             // 
             // transferCpThresText
             // 
-            this.transferCpThresText.Location = new System.Drawing.Point(118, 202);
+            this.transferCpThresText.Location = new System.Drawing.Point(118, 219);
             this.transferCpThresText.Name = "transferCpThresText";
-            this.transferCpThresText.Size = new System.Drawing.Size(100, 21);
+            this.transferCpThresText.Size = new System.Drawing.Size(100, 20);
             this.transferCpThresText.TabIndex = 18;
             this.transferCpThresText.TextChanged += new System.EventHandler(this.transferCpThresText_TextChanged);
             // 
             // evolveAllChk
             // 
             this.evolveAllChk.AutoSize = true;
-            this.evolveAllChk.Location = new System.Drawing.Point(118, 296);
+            this.evolveAllChk.Location = new System.Drawing.Point(118, 321);
             this.evolveAllChk.Name = "evolveAllChk";
             this.evolveAllChk.Size = new System.Drawing.Size(15, 14);
             this.evolveAllChk.TabIndex = 19;
@@ -258,9 +259,9 @@
             // 
             this.saveBtn.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.saveBtn.Location = new System.Drawing.Point(0, 315);
+            this.saveBtn.Location = new System.Drawing.Point(0, 340);
             this.saveBtn.Name = "saveBtn";
-            this.saveBtn.Size = new System.Drawing.Size(218, 88);
+            this.saveBtn.Size = new System.Drawing.Size(218, 95);
             this.saveBtn.TabIndex = 20;
             this.saveBtn.Text = "Save";
             this.saveBtn.UseVisualStyleBackColor = true;
@@ -275,7 +276,7 @@
             this.gMapControl1.GrayScaleMode = false;
             this.gMapControl1.HelperLineOption = GMap.NET.WindowsForms.HelperLineOptions.DontShow;
             this.gMapControl1.LevelsKeepInMemmory = 5;
-            this.gMapControl1.Location = new System.Drawing.Point(18, 15);
+            this.gMapControl1.Location = new System.Drawing.Point(18, 16);
             this.gMapControl1.MarkersEnabled = true;
             this.gMapControl1.MaxZoom = 2;
             this.gMapControl1.MinZoom = 2;
@@ -288,7 +289,7 @@
             this.gMapControl1.ScaleMode = GMap.NET.WindowsForms.ScaleModes.Integer;
             this.gMapControl1.SelectedAreaFillColor = System.Drawing.Color.FromArgb(((int)(((byte)(33)))), ((int)(((byte)(65)))), ((int)(((byte)(105)))), ((int)(((byte)(225)))));
             this.gMapControl1.ShowTileGridLines = false;
-            this.gMapControl1.Size = new System.Drawing.Size(468, 358);
+            this.gMapControl1.Size = new System.Drawing.Size(468, 388);
             this.gMapControl1.TabIndex = 22;
             this.gMapControl1.Zoom = 0D;
             this.gMapControl1.Load += new System.EventHandler(this.gMapControl1_Load);
@@ -301,9 +302,9 @@
             this.groupBox1.Controls.Add(this.trackBar);
             this.groupBox1.Controls.Add(this.gMapControl1);
             this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox1.Location = new System.Drawing.Point(233, 8);
+            this.groupBox1.Location = new System.Drawing.Point(233, 9);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(480, 408);
+            this.groupBox1.Size = new System.Drawing.Size(480, 441);
             this.groupBox1.TabIndex = 25;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Location";
@@ -312,9 +313,9 @@
             // 
             this.FindAdressButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.FindAdressButton.Location = new System.Drawing.Point(355, 379);
+            this.FindAdressButton.Location = new System.Drawing.Point(355, 410);
             this.FindAdressButton.Name = "FindAdressButton";
-            this.FindAdressButton.Size = new System.Drawing.Size(119, 24);
+            this.FindAdressButton.Size = new System.Drawing.Size(119, 26);
             this.FindAdressButton.TabIndex = 25;
             this.FindAdressButton.Text = "Find Location";
             this.FindAdressButton.UseVisualStyleBackColor = true;
@@ -323,9 +324,9 @@
             // AdressBox
             // 
             this.AdressBox.ForeColor = System.Drawing.Color.Gray;
-            this.AdressBox.Location = new System.Drawing.Point(18, 379);
+            this.AdressBox.Location = new System.Drawing.Point(18, 411);
             this.AdressBox.Name = "AdressBox";
-            this.AdressBox.Size = new System.Drawing.Size(331, 21);
+            this.AdressBox.Size = new System.Drawing.Size(331, 20);
             this.AdressBox.TabIndex = 25;
             this.AdressBox.Text = "Enter an address or a coordinate";
             this.AdressBox.TextChanged += new System.EventHandler(this.AdressBox_TextChanged);
@@ -336,10 +337,10 @@
             // 
             this.trackBar.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.trackBar.BackColor = System.Drawing.SystemColors.Info;
-            this.trackBar.Location = new System.Drawing.Point(432, 15);
+            this.trackBar.Location = new System.Drawing.Point(432, 16);
             this.trackBar.Name = "trackBar";
             this.trackBar.Orientation = System.Windows.Forms.Orientation.Vertical;
-            this.trackBar.Size = new System.Drawing.Size(45, 96);
+            this.trackBar.Size = new System.Drawing.Size(45, 104);
             this.trackBar.TabIndex = 25;
             this.trackBar.TickStyle = System.Windows.Forms.TickStyle.TopLeft;
             this.trackBar.Scroll += new System.EventHandler(this.trackBar_Scroll);
@@ -374,17 +375,17 @@
             this.panel1.Controls.Add(this.UserLoginBox);
             this.panel1.Controls.Add(this.UserPasswordBox);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Left;
-            this.panel1.Location = new System.Drawing.Point(9, 8);
+            this.panel1.Location = new System.Drawing.Point(9, 9);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(224, 408);
+            this.panel1.Size = new System.Drawing.Size(224, 441);
             this.panel1.TabIndex = 26;
             this.panel1.Paint += new System.Windows.Forms.PaintEventHandler(this.panel1_Paint);
             // 
             // TravelSpeedBox
             // 
-            this.TravelSpeedBox.Location = new System.Drawing.Point(118, 251);
+            this.TravelSpeedBox.Location = new System.Drawing.Point(118, 272);
             this.TravelSpeedBox.Name = "TravelSpeedBox";
-            this.TravelSpeedBox.Size = new System.Drawing.Size(100, 21);
+            this.TravelSpeedBox.Size = new System.Drawing.Size(100, 20);
             this.TravelSpeedBox.TabIndex = 22;
             this.TravelSpeedBox.TextChanged += new System.EventHandler(this.textBox1_TextChanged);
             this.TravelSpeedBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TravelSpeedBox_KeyPress);
@@ -392,7 +393,7 @@
             // CatchPokemonBox
             // 
             this.CatchPokemonBox.AutoSize = true;
-            this.CatchPokemonBox.Location = new System.Drawing.Point(118, 275);
+            this.CatchPokemonBox.Location = new System.Drawing.Point(118, 298);
             this.CatchPokemonBox.Name = "CatchPokemonBox";
             this.CatchPokemonBox.Size = new System.Drawing.Size(15, 14);
             this.CatchPokemonBox.TabIndex = 26;
@@ -402,51 +403,51 @@
             // CatchPokemonText
             // 
             this.CatchPokemonText.AutoSize = true;
-            this.CatchPokemonText.Location = new System.Drawing.Point(3, 275);
+            this.CatchPokemonText.Location = new System.Drawing.Point(3, 298);
             this.CatchPokemonText.Name = "CatchPokemonText";
-            this.CatchPokemonText.Size = new System.Drawing.Size(89, 12);
+            this.CatchPokemonText.Size = new System.Drawing.Size(86, 13);
             this.CatchPokemonText.TabIndex = 25;
             this.CatchPokemonText.Text = "Catch Pokemon:";
             this.CatchPokemonText.Click += new System.EventHandler(this.label7_Click);
             // 
             // transferIVThresText
             // 
-            this.transferIVThresText.Location = new System.Drawing.Point(118, 203);
+            this.transferIVThresText.Location = new System.Drawing.Point(118, 220);
             this.transferIVThresText.Name = "transferIVThresText";
-            this.transferIVThresText.Size = new System.Drawing.Size(100, 21);
+            this.transferIVThresText.Size = new System.Drawing.Size(100, 20);
             this.transferIVThresText.TabIndex = 24;
             this.transferIVThresText.TextChanged += new System.EventHandler(this.textBox2_TextChanged);
             // 
             // TravelSpeedText
             // 
             this.TravelSpeedText.AutoSize = true;
-            this.TravelSpeedText.Location = new System.Drawing.Point(3, 254);
+            this.TravelSpeedText.Location = new System.Drawing.Point(3, 275);
             this.TravelSpeedText.Name = "TravelSpeedText";
-            this.TravelSpeedText.Size = new System.Drawing.Size(113, 12);
+            this.TravelSpeedText.Size = new System.Drawing.Size(102, 13);
             this.TravelSpeedText.TabIndex = 23;
             this.TravelSpeedText.Text = "Travel Speed km/h:";
             // 
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(3, 203);
+            this.label6.Location = new System.Drawing.Point(3, 220);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(83, 12);
+            this.label6.Size = new System.Drawing.Size(70, 13);
             this.label6.TabIndex = 21;
             this.label6.Text = "IV Threshold:";
             this.label6.Click += new System.EventHandler(this.label6_Click);
             // 
             // SettingsForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(722, 424);
+            this.ClientSize = new System.Drawing.Size(722, 459);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.panel1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MinimumSize = new System.Drawing.Size(630, 334);
+            this.MinimumSize = new System.Drawing.Size(630, 359);
             this.Name = "SettingsForm";
-            this.Padding = new System.Windows.Forms.Padding(9, 8, 9, 8);
+            this.Padding = new System.Windows.Forms.Padding(9, 9, 9, 9);
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Settings";


### PR DESCRIPTION
When I use the IV Duplicate mode, I was struggling that I didn't have high enough CP pokemons to battle when I wanted to take over a gym.
In CP/IV Duplicate mode, both the highest CP and the highest IV for the same type of pokemon will be kept (If they are the same pokemon, then keep just it). In practice, not all types of the pokemons can be found in the wild, therefore this mode will result around 200 pokemons in the bag at maximum, but the theoretical maximum number can be 302. This problem can be solved by upgrading the pokemon storage.
