### PR TITLE
Fixed a nullpionter in the familylist linq method

### DIFF
--- a/PokemonGo/RocketAPI/Window/MainForm.cs
+++ b/PokemonGo/RocketAPI/Window/MainForm.cs
@@ -1383,7 +1383,7 @@ namespace PokemonGo.RocketAPI.Window
                         .Where(p => p != null && p?.PokemonId > 0)
                         .OrderByDescending(key => key.Cp);
                 families = inventory.InventoryDelta.InventoryItems
-                    .Select(i => i.InventoryItemData.Candy.FamilyId)
+                    .Select(i => i.InventoryItemData?.Candy?.FamilyId ?? 0)
                     .Where(p => p > 0)
                     .OrderByDescending(p => p);
 


### PR DESCRIPTION
When hovering the pokemon grid/refresh button i've recieved a error. I've added some null conditional operators
